### PR TITLE
feat: allow manual focus selection for catalogue

### DIFF
--- a/src/components/blocks/Block.astro
+++ b/src/components/blocks/Block.astro
@@ -1,6 +1,6 @@
 ---
 import type { ImageMetadata } from "astro"
-import InternalImage from "../images/InternalImage.astro"
+import Image from "../images/Image.astro"
 /**
  * Used to present an something as a card, also a link to that something.
  */
@@ -23,20 +23,15 @@ const { image, imageDark, imageAlt = "", to, imageFocusY } = Astro.props
 		style={typeof imageFocusY === "number" ? `--image-focus-y: ${imageFocusY}%` : undefined}
 	>
 		{
-			image &&
-				(!imageDark ? (
-					<InternalImage source={image} alt={imageAlt} formats={formats} />
-				) : (
-					<>
-						<InternalImage source={image} alt={imageAlt} formats={formats} class="dark:hidden" />
-						<InternalImage
-							source={imageDark}
-							alt={imageAlt}
-							formats={formats}
-							class="hidden dark:block"
-						/>
-					</>
-				))
+                        image &&
+                                (!imageDark ? (
+                                        <Image src={image} alt={imageAlt} formats={formats} />
+                                ) : (
+                                        <>
+                                                <Image src={image} alt={imageAlt} formats={formats} class="dark:hidden" />
+                                                <Image src={imageDark} alt={imageAlt} formats={formats} class="hidden dark:block" />
+                                        </>
+                                ))
 		}
 	</div>
 	<article>

--- a/src/pages/api/catalogue/image.ts
+++ b/src/pages/api/catalogue/image.ts
@@ -1,0 +1,63 @@
+import type { APIContext } from "astro"
+import { fetchGame, coverUrl } from "./sources/igdb"
+import { fetchBoardGame } from "./sources/bgg"
+import { fetchMovie, fetchShow, posterUrl } from "./sources/tmdb"
+import { fetchAlbum, albumCoverUrl } from "./sources/spotify"
+import { computeImageFocusY } from "../../../imageFocus"
+
+export const prerender = false
+
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+export async function POST({ request }: APIContext): Promise<Response> {
+  try {
+    const body = await request.json()
+    const source: string | undefined = body?.source
+    const source_id: string | undefined = body?.source_id
+    if (!source || !source_id) return json({ error: "Bad Request" }, 400)
+
+    let source_img = ""
+    switch (source) {
+      case "IGDB": {
+        const game = await fetchGame(Number(source_id))
+        if (game?.cover?.image_id) source_img = coverUrl(game.cover.image_id)
+        break
+      }
+      case "BGG": {
+        const game = await fetchBoardGame(Number(source_id))
+        if (game?.image) source_img = game.image
+        break
+      }
+      case "TMDB_MOVIE": {
+        const movie = await fetchMovie(Number(source_id))
+        if (movie?.poster_path) source_img = posterUrl(movie.poster_path)
+        break
+      }
+      case "TMDB_TV": {
+        const show = await fetchShow(Number(source_id))
+        if (show?.poster_path) source_img = posterUrl(show.poster_path)
+        break
+      }
+      case "SPOTIFY": {
+        const album = await fetchAlbum(String(source_id))
+        if (album?.images?.length) source_img = albumCoverUrl(album)
+        break
+      }
+      default:
+        return json({ error: "Unknown source" }, 400)
+    }
+
+    if (!source_img) return json({ error: "Image not found" }, 404)
+
+    const source_img_focus_y = await computeImageFocusY(source_img)
+    return json({ source_img, source_img_focus_y })
+  } catch (err) {
+    console.error("POST /image failed:", err)
+    return json({ error: "Server error" }, 500)
+  }
+}

--- a/src/pages/api/catalogue/reviews.ts
+++ b/src/pages/api/catalogue/reviews.ts
@@ -180,6 +180,7 @@ export async function POST({ request }: APIContext): Promise<Response> {
       rating,
       emotions,
       comment = "",
+      focus_y,
     }: {
       date?: string
       source: string
@@ -187,6 +188,7 @@ export async function POST({ request }: APIContext): Promise<Response> {
       rating: number
       emotions: number[]
       comment?: string
+      focus_y?: number
     } = body
 
     const isValid =
@@ -206,7 +208,10 @@ export async function POST({ request }: APIContext): Promise<Response> {
     let source_link = ""
     let source_img = ""
     let meta = ""
-    let source_img_focus_y: number | null = null
+    let source_img_focus_y: number | null =
+      typeof focus_y === "number" && focus_y >= 0 && focus_y <= 100
+        ? Math.round(focus_y)
+        : null
 
     switch (source) {
       case "IGDB": {
@@ -274,7 +279,8 @@ export async function POST({ request }: APIContext): Promise<Response> {
         break
     }
 
-    if (source_img) source_img_focus_y = await computeImageFocusY(source_img)
+    if (source_img && source_img_focus_y === null)
+      source_img_focus_y = await computeImageFocusY(source_img)
 
     // Insert row
     const client = getClient()

--- a/src/pages/cataloguer.astro
+++ b/src/pages/cataloguer.astro
@@ -50,88 +50,174 @@ const pageTitle = "Cataloguer"
 					</div>
 				</fieldset>
 				<button type="submit" class="button col-span-2"> Submit Review </button>
-			</form>
-		</section>
-	</section>
-	<script>
-		import type { Emotion } from "./api/catalogue/emotions"
+                        </form>
+                </section>
+       </section>
+       <div
+               id="focus-modal"
+               class="fixed inset-0 z-10 hidden grid place-items-center bg-black/70"
+       >
+               <div class="flex max-h-[70vh] flex-col gap-4 rounded bg-white p-4 dark:bg-neutral-900">
+                       <div class="relative max-h-[60vh] overflow-hidden">
+                               <img id="focus-image" class="block max-h-[60vh]" alt="" />
+                               <div
+                                       id="focus-rect"
+                                       class="pointer-events-none absolute inset-x-0 border-2 border-sky-500"
+                                       style="height:40%;top:50%;transform:translateY(-50%);"></div>
+                       </div>
+                       <input id="focus-range" type="range" min="0" max="100" value="50" />
+                       <div class="flex justify-end gap-2">
+                               <button type="button" id="focus-cancel">Cancel</button>
+                               <button type="button" id="focus-confirm" class="button">Use focus</button>
+                       </div>
+               </div>
+       </div>
+       <script>
+                import type { Emotion } from "./api/catalogue/emotions"
 
-		// If server-side fetch failed, try to fetch emotions client-side
-		async function loadEmotions() {
-			if (document.querySelector("fieldset p")) {
-				try {
-					const response = await fetch("/api/catalogue/emotions")
-					if (!response.ok)
-						throw new Error(`HTTP ${response.status} ${response.statusText}:  ${response.text()}`)
+                async function loadEmotions() {
+                        if (document.querySelector("fieldset p")) {
+                                try {
+                                        const response = await fetch("/api/catalogue/emotions")
+                                        if (!response.ok)
+                                                throw new Error(`HTTP ${response.status} ${response.statusText}:  ${response.text()}`)
 
-					const emotions: Emotion[] = await response.json()
-					const emotionsContainer = document.querySelector("fieldset div")
-					if (emotionsContainer) {
-						emotionsContainer.innerHTML = ""
+                                        const emotions: Emotion[] = await response.json()
+                                        const emotionsContainer = document.querySelector("fieldset div")
+                                        if (emotionsContainer) {
+                                                emotionsContainer.innerHTML = ""
 
-						emotions
-							.sort((a, b) => a.name.localeCompare(b.name))
-							.forEach((emotion) => {
-								const wrapper = document.createElement("label")
-								wrapper.innerHTML = `
-																	<input type="checkbox" name="emotions" value=${emotion.id} class="hidden" />
-																	${emotion.emoji} ${emotion.name}
+                                                emotions
+                                                        .sort((a, b) => a.name.localeCompare(b.name))
+                                                        .forEach((emotion) => {
+                                                                const wrapper = document.createElement("label")
+                                                                wrapper.innerHTML = `
+                                                                                                                               <input type="checkbox" name="emotions" value=${emotion.id} class="hidden" />
+                                                                                                                               ${emotion.emoji} ${emotion.name}
                                 `
-								emotionsContainer.appendChild(wrapper)
-							})
-					}
-				} catch (error) {
-					console.error("Failed to load emotions client-side:", error)
-				}
-			}
-		}
+                                                                emotionsContainer.appendChild(wrapper)
+                                                        })
+                                        }
+                                } catch (error) {
+                                        console.error("Failed to load emotions client-side:", error)
+                                }
+                        }
+                }
 
-		document.addEventListener("DOMContentLoaded", loadEmotions)
+               async function pickFocus(imgSrc: string, initial: number | null): Promise<number | null> {
+                       const modal = document.getElementById("focus-modal") as HTMLDivElement
+                       const img = modal.querySelector("#focus-image") as HTMLImageElement
+                       const rect = modal.querySelector("#focus-rect") as HTMLDivElement
+                       const range = modal.querySelector("#focus-range") as HTMLInputElement
+                       const confirm = modal.querySelector("#focus-confirm") as HTMLButtonElement
+                       const cancel = modal.querySelector("#focus-cancel") as HTMLButtonElement
 
-		// Form validation
-		const form = document.querySelector("form")
-		form?.addEventListener("submit", async (event) => {
-			event.preventDefault() // stay on page
+                       return new Promise((resolve) => {
+                               img.src = imgSrc
+                               range.value = String(initial ?? 50)
+                               rect.style.top = range.value + "%"
 
-			// Check if the form is valid
-			const data = new FormData(form)
+                               function update() {
+                                       rect.style.top = range.value + "%"
+                               }
 
-			const emotions = [...form.querySelectorAll('input[name="emotions"]:checked')].map((c) =>
-				Number((c as HTMLInputElement).value)
-			)
+                               function onImageClick(event: MouseEvent) {
+                                       const bounds = img.getBoundingClientRect()
+                                       const y = ((event.clientY - bounds.top) / bounds.height) * 100
+                                       range.value = String(Math.round(y))
+                                       update()
+                               }
 
-			if (emotions.length === 0 || emotions.length > 3) {
-				alert("Choose between 1 and 3 emotions")
-				return
-			}
+                               function clean() {
+                                       range.removeEventListener("input", update)
+                                       img.removeEventListener("click", onImageClick)
+                                       confirm.removeEventListener("click", onConfirm)
+                                       cancel.removeEventListener("click", onCancel)
+                                       modal.classList.add("hidden")
+                               }
 
-			const payload = {
-				password: data.get("password"),
-				date: data.get("date"),
-				source: data.get("source"),
-				source_id: data.get("source_id"),
-				rating: Number(data.get("rating")),
-				emotions,
-				comment: data.get("comment") ?? "",
-			}
+                               function onConfirm() {
+                                       clean()
+                                       resolve(Number(range.value))
+                               }
 
-			try {
-				const res = await fetch("/api/catalogue/reviews", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(payload),
-				})
+                               function onCancel() {
+                                       clean()
+                                       resolve(null)
+                               }
 
-				if (!res.ok) {
-					const { error } = await res.json()
-					throw new Error(error ?? "Unknown error")
-				}
+                               range.addEventListener("input", update)
+                               img.addEventListener("click", onImageClick)
+                               confirm.addEventListener("click", onConfirm)
+                               cancel.addEventListener("click", onCancel)
 
-				alert("Review saved ✔️")
-				form.reset()
-			} catch (e) {
-				alert(`❌ Cannot save review: ${(e as Error).message}`)
-			}
-		})
-	</script>
+                               modal.classList.remove("hidden")
+                       })
+               }
+
+               document.addEventListener("DOMContentLoaded", () => {
+                       loadEmotions()
+                       const form = document.querySelector("form") as HTMLFormElement | null
+                       form?.addEventListener("submit", async (event) => {
+                               event.preventDefault()
+
+                               const data = new FormData(form)
+                               const emotions = [...form.querySelectorAll('input[name="emotions"]:checked')].map((c) =>
+                                       Number((c as HTMLInputElement).value)
+                               )
+
+                               if (emotions.length === 0 || emotions.length > 3) {
+                                       alert("Choose between 1 and 3 emotions")
+                                       return
+                               }
+
+                               const payload = {
+                                       password: data.get("password"),
+                                       date: data.get("date"),
+                                       source: data.get("source"),
+                                       source_id: data.get("source_id"),
+                                       rating: Number(data.get("rating")),
+                                       emotions,
+                                       comment: data.get("comment") ?? "",
+                               }
+
+                               const imgRes = await fetch("/api/catalogue/image", {
+                                       method: "POST",
+                                       headers: { "Content-Type": "application/json" },
+                                       body: JSON.stringify({
+                                               source: payload.source,
+                                               source_id: payload.source_id,
+                                       }),
+                               })
+
+                               if (!imgRes.ok) {
+                                       alert("Cannot load image for focus selection")
+                                       return
+                               }
+
+                               const { source_img, source_img_focus_y } = await imgRes.json()
+                               const focus = await pickFocus(source_img, source_img_focus_y)
+                               if (focus === null) return
+                               ;(payload as any).focus_y = focus
+
+                               try {
+                                       const res = await fetch("/api/catalogue/reviews", {
+                                               method: "POST",
+                                               headers: { "Content-Type": "application/json" },
+                                               body: JSON.stringify(payload),
+                                       })
+
+                                       if (!res.ok) {
+                                               const { error } = await res.json()
+                                               throw new Error(error ?? "Unknown error")
+                                       }
+
+                                       alert("Review saved ✔️")
+                                       form.reset()
+                               } catch (e) {
+                                       alert(`❌ Cannot save review: ${(e as Error).message}`)
+                               }
+                       })
+               })
+       </script>
 </Layout>


### PR DESCRIPTION
## Summary
- add modal to pick custom focusY before saving reviews
- support user-provided focus in reviews API
- expose image preview endpoint to compute initial focus
- replace dialog-based picker with cross-browser modal
- use Image component for block cards
- ensure focus picker waits for user confirmation before submitting

## Testing
- `pnpm run astro check`


------
https://chatgpt.com/codex/tasks/task_e_68a49dd9dcb0832ba7e974fc6141fa07